### PR TITLE
use sensor names for prom metrics

### DIFF
--- a/RoomWeather.h
+++ b/RoomWeather.h
@@ -29,10 +29,10 @@ class RoomWeather
     void Connect(char ssid[], char password[], String ipStr, String submaskStr, String gatewayStr);
     void StartWiFi(char ssid[], char password[]);
     String BuildMetrics();
-    String GetTemperatureMetrics();
-    String GetVOCMetrics();
+    String GetHTU31DMetrics();
+    String GetSGP30Metrics();
     String GetLocationLabel();
-    String ToProm(String value, String name, String label);
+    String ToProm(String name, String value, String metric, String unit);
 };
 
 #endif

--- a/sensor/sensor.ino
+++ b/sensor/sensor.ino
@@ -21,7 +21,5 @@ void setup() {
 
 void loop() {
   rw->Scan();
-  // Serial.print("VOC: ");
-  // Serial.println(rw->GetSGP30VOC());
   rw->Serve();
 }


### PR DESCRIPTION
This PR cleans up prometheus metrics by naming each metric after its specific sensor.