### PR TITLE
Set _sensorFound to true if sensor is detected

### DIFF
--- a/RW_HTU31D.cpp
+++ b/RW_HTU31D.cpp
@@ -7,10 +7,7 @@ RW_HTU31D::RW_HTU31D()
 }
 
 bool RW_HTU31D::Detect() {
-    if(_htu.begin(0x40)) {
-        _sensorFound = true;
-    }
-
+    _sensorFound = _htu.begin(0x40);
     RW_Helper::Htu31dFound = _sensorFound;
     return _sensorFound;
 }

--- a/RW_PMSA003I.cpp
+++ b/RW_PMSA003I.cpp
@@ -7,10 +7,7 @@ RW_PMSA003I::RW_PMSA003I()
 }
 
 bool RW_PMSA003I::Detect() {
-    if(_pm25.begin_I2C()) {
-        _sensorFound = true;
-    }
-
+    _sensorFound = _pm25.begin_I2C();
     RW_Helper::Pmsa003iFound = _sensorFound;
     return _sensorFound;
 }

--- a/RW_SGP30.cpp
+++ b/RW_SGP30.cpp
@@ -7,10 +7,7 @@ RW_SGP30::RW_SGP30()
 }
 
 bool RW_SGP30::Detect() {
-    if(sgp.begin()) {
-        _sensorFound = true;
-    }
-
+    _sensorFound = sgp.begin();
     RW_Helper::Sgp30Found = _sensorFound;
     return _sensorFound;
 }


### PR DESCRIPTION
Instead of setting _sensorFound = true if the sensor is detected, _sensorFound is set to true when the sensor is detected.