### PR TITLE
cleanup sample sketches, add some details to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ rw->Values.Htu31d.TemperatureCelsius;
 rw->Values.Htu31d.TemperatureFahrenheit;
 ```
 
+### Features
+
+* Fahrenheit temperature is made available by converting the sensor's celsius reading.
+* Absolute humitidy is made available by a a calculation using the sensor's humidity and temperature readings.
+
 ## SGP30 VOC & C02
 
 ### Values
@@ -137,16 +142,4 @@ values->Pmsa003i.Particles10um;
 values->Pmsa003i.Particles25um;
 values->Pmsa003i.Particles50um;
 values->Pmsa003i.Particles100um;
-```
-
-# Configuring Sample Sketch
-
-To run the included `prometheus.ino` sketch, you must create a file called `RoomWeatherConfig.h` in your include path.
-
-The file should define the following:
-
-```
-#define RW_SECRET_SSID "your_wifi_ssid"
-#define RW_SECRET_PASS "your_wifi_password"
-#define RW_LOCATION "location_or_name_of_room_weather_instance"
 ```

--- a/examples/prometheus/prometheus.ino
+++ b/examples/prometheus/prometheus.ino
@@ -1,8 +1,7 @@
 #include "RoomWeather.h"
-#include "RoomWeatherConfig.h"
 
-char ssid[] = RW_SECRET_SSID;
-char pass[] = RW_SECRET_PASS;
+char ssid[] = "your_wifi_ssid";
+char pass[] = "your_wifi_password";
 
 RoomWeather *rw;
 
@@ -15,7 +14,7 @@ void setup() {
 
   Serial.println("Serial started.");
 
-  rw = new RoomWeather(RW_LOCATION, ssid, pass);
+  rw = new RoomWeather("location_of_your_sensors", ssid, pass);
   rw->Detect();
 }
 


### PR DESCRIPTION
This PR simplifies the included prometheus example sketch, and adds some details about HTU31D to the readme to indicate that some available fields are actually calculated rather than being read by the sensor.