### PR TITLE
Allow Non ESP32 Boards to Compile Room Weather

### DIFF
--- a/RW_Wifi.cpp
+++ b/RW_Wifi.cpp
@@ -1,3 +1,4 @@
+#if defined(ESP32)
 #include "RW_Wifi.h"
 
 RW_Wifi::RW_Wifi(char ssid[], char password[]) {
@@ -77,3 +78,4 @@ void RW_Wifi::PrintWifiStatus() {
 
   Serial.println("---------------");
 }
+#endif

--- a/RW_Wifi.h
+++ b/RW_Wifi.h
@@ -1,6 +1,7 @@
 #ifndef RW_Wifi_h
 #define RW_Wifi_h
 
+#if defined(ESP32)
 #include <WiFi.h>
 
 class RW_Wifi
@@ -13,5 +14,6 @@ class RW_Wifi
     void StartWiFi(char ssid[], char password[]);
     void PrintWifiStatus();
 };
+#endif
 
 #endif

--- a/RoomWeather.cpp
+++ b/RoomWeather.cpp
@@ -6,11 +6,13 @@ RoomWeather::RoomWeather(String location) {
     Load();
 }
 
+#if defined(ESP32)
 RoomWeather::RoomWeather(String location, char ssid[], char password[]) {
     _location = location;
     _wifi = new RW_Wifi(ssid, password);
     Load();
 }
+#endif
 
 void RoomWeather::Detect() {
     Serial.println("Detecting sensors.");
@@ -98,6 +100,7 @@ void RoomWeather::DoRead() {
     }
 }
 
+#if defined(ESP32)
 void RoomWeather::ServeMetrics() {
     if(!_wifi) {
         Serial.println("Attempted to serve metrics over wifi, but wifi is not connected.");
@@ -106,3 +109,4 @@ void RoomWeather::ServeMetrics() {
 
     _wifi->Serve(BuildMetrics());
 }
+#endif

--- a/RoomWeather.h
+++ b/RoomWeather.h
@@ -7,7 +7,9 @@
 #define RW_SGP40_INDEX 2
 #define RW_PMSA003I_INDEX 3
 
-#include "RW_Wifi.h"
+#if defined(ESP32)
+    #include "RW_Wifi.h"
+#endif
 #include "RW_HTU31D.h"
 #include "RW_SGP30.h"
 #include "RW_SGP40.h"
@@ -19,15 +21,21 @@ class RoomWeather
   public:
     RW_Values* Values;
     RoomWeather(String location);
-    RoomWeather(String location, char ssid[], char password[]);
+    #if defined(ESP32)
+      RoomWeather(String location, char ssid[], char password[]);
+    #endif
     void Detect();
     void Read();
     void Read(int interval);
     void Print();
     void Print(int index);
-    void ServeMetrics();
+    #if defined(ESP32)
+      void ServeMetrics();
+    #endif
   private:
-    RW_Wifi *_wifi;
+    #if defined(ESP32)
+      RW_Wifi *_wifi;
+    #endif
     RW_Sensor* _sensors[SUPPORTED_SENSOR_COUNT];
     String _location;
     unsigned long _lastReadTime;


### PR DESCRIPTION
This PR adds a compiler directive to prevent compiling code that leverages ESP32 WiFi features if an ESP32 board is not being used. This will allow RoomWeather to compile on non wifi enabled boards.